### PR TITLE
Consolidate operations defined in configs under single key

### DIFF
--- a/main/app.py
+++ b/main/app.py
@@ -61,7 +61,7 @@ def main(
   data = schema.get_model(name='main.app.Data', data=locals())
 
   data = independent.process_operations(
-    operations=CONFIG.main_operations,
+    operations=CONFIG.operations.main,
     functions=LOCALS,
     data=data, )
   if not hasattr(data, 'tests'):
@@ -297,7 +297,7 @@ def handle_casting_output(
 
 def run_test_for_function(test: sns | None = None) -> sns:
   test = independent.process_operations(
-    operations=CONFIG.run_test_for_functions_operations,
+    operations=CONFIG.operations.run_test_for_functions,
     functions=LOCALS,
     data=test, )
   return test.assertions
@@ -325,7 +325,7 @@ def run_tests(locations: List[sns] | None = None) -> sns:
 
   for i, item in enumerate(locations):
     result = independent.process_operations(
-      operations=CONFIG.run_tests_operations,
+      operations=CONFIG.operations.run_tests,
       functions=LOCALS,
       data=item, )
     tests.extend(result.tests)

--- a/main/app.py
+++ b/main/app.py
@@ -53,20 +53,14 @@ def main(
   logging_enabled: bool | None = None,
 ) -> list:
   timestamp = independent.get_timestamp()
-  logger.create_logger(
-    logging_enabled=logging_enabled,
-    project_directory=project_directory, )
+  logger.create_logger(logging_enabled=logging_enabled, project_directory=project_directory)
 
-  # data = locations.main(**locals())
   data = schema.get_model(name='main.app.Data', data=locals())
-
   data = independent.process_operations(
     operations=CONFIG.operations.main,
     functions=LOCALS,
     data=data, )
-  if not hasattr(data, 'tests'):
-    data.tests = []
-  return data.tests
+  return getattr(data, 'tests', None) or []
 
 
 def handle_id(

--- a/main/app.yaml
+++ b/main/app.yaml
@@ -67,28 +67,25 @@ test_kinds:
 # Order of operations for testing functions
 # and the fields/values of an object that are
 # required to run functions
-run_test_for_functions_operations:
-- handle_id
-- handle_module
-- handle_resources
-- set_environment
-- process_patches
-- handle_casting_arguments
-- get_function
-- get_function_output
-- handle_casting_output
-- process_assertions
-
-
-run_tests_operations:
-- get_tests
-- run_test_handler
-# - post_processing
-
-
-main_operations:
-- get_locations
-- run_tests
+operations:
+  run_test_for_functions:
+  - handle_id
+  - handle_module
+  - handle_resources
+  - set_environment
+  - process_patches
+  - handle_casting_arguments
+  - get_function
+  - get_function_output
+  - handle_casting_output
+  - process_assertions
+  run_tests:
+  - get_tests
+  - run_test_handler
+  # - post_processing
+  main:
+  - get_locations
+  - run_tests
 
 
 unpack_kinds:

--- a/main/process/assertions.py
+++ b/main/process/assertions.py
@@ -36,7 +36,7 @@ def main(
     assertion = independent.process_operations(
       data=assertion,
       functions=LOCALS,
-      operations=CONFIG.main_operations, )
+      operations=CONFIG.operations.main, )
     assertions[i] = assertion
 
   n = len(assertions)

--- a/main/process/assertions.yml
+++ b/main/process/assertions.yml
@@ -53,9 +53,10 @@ schema:
       description: Flag indicating whether a test was passed or not
 
 
-main_operations:
-- get_assertion_method
-- reset_output_value
-- cast_output
-- get_assertion_result
-- handle_failed_assertion
+operations:
+  main:
+  - get_assertion_method
+  - reset_output_value
+  - cast_output
+  - get_assertion_result
+  - handle_failed_assertion

--- a/main/process/casts/app.py
+++ b/main/process/casts/app.py
@@ -30,7 +30,7 @@ def main(
     data.module = module
     data.object = object_
     data = independent.process_operations(
-      operations=CONFIG.main_operations,
+      operations=CONFIG.operations.main,
       functions=LOCALS,
       data=data, )
     object_ = data.object

--- a/main/process/casts/app.yml
+++ b/main/process/casts/app.yml
@@ -50,8 +50,9 @@ empty_values:
 - '0'
 
 
-main_operations:
-- get_cast_method
-- get_temp_object
-- handle_casting
-- reset_object
+operations:
+  main:
+  - get_cast_method
+  - get_temp_object
+  - handle_casting
+  - reset_object

--- a/main/process/get_tests/app.py
+++ b/main/process/get_tests/app.py
@@ -24,7 +24,7 @@ def main(
   del yaml, module, module_location, module_route, resources
 
   data = independent.process_operations(
-    operations=CONFIG.main_operations,
+    operations=CONFIG.operations.main,
     functions=LOCALS,
     data=data, )
   return data

--- a/main/process/get_tests/app.yml
+++ b/main/process/get_tests/app.yml
@@ -203,11 +203,12 @@ empty_values:
 #     default: null
 
 
-main_operations:
-- get_configurations_and_tests
-- format_locations
-- add_locations_to_configurations
-- get_expanded_nodes
+operations:
+  main:
+  - get_configurations_and_tests
+  - format_locations
+  - add_locations_to_configurations
+  - get_expanded_nodes
 
 
 content_keys_and_defaults:

--- a/main/process/get_tests/expand_node.py
+++ b/main/process/get_tests/expand_node.py
@@ -19,7 +19,7 @@ def main(
 ) -> sns:
   data = sns(**locals())
   data = independent.process_operations(
-    operations=CONFIG.main_operations,
+    operations=CONFIG.operations.main,
     functions=LOCALS,
     data=data, )
   return sns(nodes=data.nodes)

--- a/main/process/get_tests/expand_node.yml
+++ b/main/process/get_tests/expand_node.yml
@@ -17,7 +17,8 @@ yaml_extensions:
 - .yml
 
 
-main_operations:
-- add_configurations_to_root_node
-- get_expanded_nodes
-- remove_roots_of_expanded_nodes
+operations:
+  main:
+  - add_configurations_to_root_node
+  - get_expanded_nodes
+  - remove_roots_of_expanded_nodes

--- a/main/process/locations.py
+++ b/main/process/locations.py
@@ -33,7 +33,7 @@ def main(
   data = sns(**locals())
   data = independent.process_operations(
     functions=LOCALS,
-    operations=CONFIG.main_operations,
+    operations=CONFIG.operations.main,
     data=data, )
 
   data.locations = data.locations or []

--- a/main/process/locations.yaml
+++ b/main/process/locations.yaml
@@ -51,11 +51,12 @@ empty_values:
 - 'False'
 
 
-main_operations:
-- format_paths
-- format_yaml_suffix
-- format_resources_folder_name
-- format_exclude_files
-- get_module_and_yaml_location_when_path_kind_is_file
-- get_module_and_yaml_location_when_path_kind_is_directory
-- get_location_of_resources
+operations:
+  main:
+  - format_paths
+  - format_yaml_suffix
+  - format_resources_folder_name
+  - format_exclude_files
+  - get_module_and_yaml_location_when_path_kind_is_file
+  - get_module_and_yaml_location_when_path_kind_is_directory
+  - get_location_of_resources

--- a/main/process/patches.py
+++ b/main/process/patches.py
@@ -24,7 +24,7 @@ def main(
   for patch in patches:
     data = pre_processing(patch=patch, module=module)
     data = independent.process_operations(
-      operations=CONFIG.main_operations,
+      operations=CONFIG.operations.main,
       functions=LOCALS,
       data=data, )
     module = data.module

--- a/main/process/patches.yml
+++ b/main/process/patches.yml
@@ -3,9 +3,10 @@ environment:
   DEBUG: ${YAML_TESTING_FRAMEWORK_DEBUG}
 
 
-main_operations:
-- get_patch_method
-- patch_module
+operations:
+  main:
+  - get_patch_method
+  - patch_module
 
 
 empty_values:

--- a/main/utils/get_config.py
+++ b/main/utils/get_config.py
@@ -20,6 +20,7 @@ operations:
   - format_config_location
   - get_content_from_files
   - format_content_keys
+format_keys:
 - environment
 - schema
 - operations
@@ -78,9 +79,6 @@ def get_yaml_content_wrapper(location: str | None = None) -> sns:
   return independent.get_yaml_content(location=location)
 
 
-FIELDS = ['environment', 'schema', 'config']
-
-
 def get_content_from_files(
   environment: str | None = None,
   schema: str | None = None,
@@ -91,8 +89,7 @@ def get_content_from_files(
   data = sns(content=sns())
   message = []
 
-  for name in FIELDS:
-    location = locals_[name]
+  for name, location in locals_.items():
     content = get_yaml_content_wrapper(location=location)
     setattr(data.content, name, content.content)
     if getattr(content, 'log', None):
@@ -104,8 +101,8 @@ def get_content_from_files(
   return data
 
 
-def format_specified_content_keys(content: sns | None = None) -> sns:
-  for key in CONFIG.specified_content_keys:
+def format_content_keys(content: sns | None = None) -> sns:
+  for key in CONFIG.format_keys:
     value = {}
     content = content or sns(config={})
 
@@ -123,9 +120,6 @@ def format_specified_content_keys(content: sns | None = None) -> sns:
 
 
 def format_environment_content(value: dict | None = None) -> sns:
-  # if not isinstance(value, dict):
-  #   return value
-
   for name, variable in value.items():
     if str(variable).find('$') == 0:
       value[name] = None

--- a/main/utils/get_config.py
+++ b/main/utils/get_config.py
@@ -16,12 +16,10 @@ yaml_extensions:
 - .yaml
 - .yml
 operations:
-- format_config_location
-- get_content_from_files
-- format_specified_content_keys
-# - format_environment_content
-# - format_schema_content
-specified_content_keys:
+  main:
+  - format_config_location
+  - get_content_from_files
+  - format_content_keys
 - environment
 - schema
 DEBUG: ${YAML_TESTING_FRAMEWORK_DEBUG}

--- a/main/utils/get_config.py
+++ b/main/utils/get_config.py
@@ -22,12 +22,13 @@ operations:
   - format_content_keys
 - environment
 - schema
-DEBUG: ${YAML_TESTING_FRAMEWORK_DEBUG}
+- operations
 module_extension: .py
 '''
 CONFIG = os.path.expandvars(CONFIG)
 CONFIG = pyyaml.safe_load(CONFIG)
 CONFIG = sns(**CONFIG)
+CONFIG.operations = sns(**CONFIG.operations)
 
 LOCALS= locals()
 
@@ -41,7 +42,7 @@ def main(
   data = sns(**locals())
   data.module = data.module or inspect.stack()[1].filename
   data = independent.process_operations(
-    operations=CONFIG.operations,
+    operations=CONFIG.operations.main,
     functions=LOCALS,
     data=data, )
   data = get_object.main(parent=data, route='content.config') or {}
@@ -84,6 +85,7 @@ def get_content_from_files(
   environment: str | None = None,
   schema: str | None = None,
   config: str | None = None,
+  operations: str | None = None,
 ) -> sns:
   locals_ = locals()
   data = sns(content=sns())
@@ -135,6 +137,11 @@ def format_schema_content(value: dict | None = None) -> sns:
     content=value,
     sns_models_flag=True, )
   return value.models
+
+
+def format_operations_content(value: dict | None = None) -> sns:
+  value = value or {}
+  return sns(**value)
 
 
 def examples() -> None:

--- a/main/utils/invoke_testing_method.py
+++ b/main/utils/invoke_testing_method.py
@@ -41,6 +41,7 @@ CONFIG = '''
 '''
 CONFIG = yaml.safe_load(CONFIG)
 CONFIG = sns(**CONFIG)
+CONFIG.operations = sns(**CONFIG.operations)
 
 YAML_TESTING_FRAMEWORK_DEBUG = os.getenv('YAML_TESTING_FRAMEWORK_DEBUG')
 
@@ -63,7 +64,7 @@ def main(
   data = sns(**locals())
   data = independent.process_operations(
     data=data,
-    operations=CONFIG.main_operations,
+    operations=CONFIG.operations.main,
     functions=LOCALS, )
   return getattr(data, 'result', [])
 

--- a/main/utils/invoke_testing_method.py
+++ b/main/utils/invoke_testing_method.py
@@ -33,10 +33,11 @@ CONFIG = '''
     method: plugin
     # location: .
     logging_enabled: true
-  main_operations:
-  - set_default_values_for_arguments
-  - set_location
-  - run_tests_using_invocation_method
+  operations:
+    main:
+    - set_default_values_for_arguments
+    - set_location
+    - run_tests_using_invocation_method
 '''
 CONFIG = yaml.safe_load(CONFIG)
 CONFIG = sns(**CONFIG)


### PR DESCRIPTION
Operations should defined under a single key in config YAML files, and be accessible using dot notation.