### PR TITLE
Remove unused references to resources folder name

### DIFF
--- a/assertions/app.py
+++ b/assertions/app.py
@@ -12,10 +12,6 @@ from typing import Any, Awaitable, Callable
 from main.utils import get_config, get_object, independent
 
 
-MODULE = __file__
-CONFIG = get_config.main()
-
-
 @dc.dataclass
 class DataClass:
   pass

--- a/assertions/app.yaml
+++ b/assertions/app.yaml
@@ -1,2 +1,0 @@
-environment:
-  ROOT_DIR: $YAML_TESTING_FRAMEWORK_ROOT_DIR

--- a/main/_resources/app/add_test.yaml
+++ b/main/_resources/app/add_test.yaml
@@ -17,5 +17,5 @@ tests:
       a: 1
       b: '1'
     assertions:
-    - method: assertions.app.check_equals
-      expected: 3
+    - method: assertions.app.check_exception
+      expected: TypeError

--- a/main/_resources/app/app.py
+++ b/main/_resources/app/app.py
@@ -54,9 +54,7 @@ async def subtract(data: dict) -> int:
 def examples() -> None:
   from main.utils import invoke_testing_method
 
-  invoke_testing_method.main(
-    resources_folder_name='_resources',
-    resource_flag=True, )
+  invoke_testing_method.main(resources_folder_name='_resources', resource_flag=True)
 
 
 if __name__ == '__main__':

--- a/main/_resources/plugin.py
+++ b/main/_resources/plugin.py
@@ -85,7 +85,6 @@ def pytest_configure_resource(
 
     ini_cache = sns(
       yaml_suffix='_test',
-      resources_folder_name='_resources',
       project_path=PARENT_MODULE,
       resources='resources', ).__dict__
     opt_2_dest = {}

--- a/main/app.py
+++ b/main/app.py
@@ -47,7 +47,6 @@ def main(
   include_files: str | List[str] | None = None,
   exclude_functions: str | List[str] | None = None,
   include_functions: str | List[str] | None = None,
-  resources_folder_name: str | None = None,
   resources: str | list | None = None,
   yaml_suffix: str | None = None,
   logging_enabled: bool | None = None,

--- a/main/app_test.yaml
+++ b/main/app_test.yaml
@@ -27,25 +27,20 @@ tests:
     arguments:
       project_path: ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/_resources/app/add.py
       yaml_suffix: _test
-      resources_folder_name: resources_folder_name
       resources:
       - ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/assertions/app.py
     assertions:
     - method: assertions.app.check_equals
       expected:
-      - expected: '3
-      
-          ...'
+      - expected: TypeError
         id: ' .main._resources.app.add.add - 0.1 - Return the result of adding two integers '
         id_short: .main._resources.app.add.add
-        log: '[]'
-        method: check_equals
-        method_name: assertions.app.check_equals
+        log: null
+        method: check_exception
+        method_name: assertions.app.check_exception
         module: null
-        output: '!!python/object/apply:builtins.TypeError
-
-          - ''unsupported operand type(s) for +: ''''int'''' and ''''str'''''''
-        passed: false
+        output: TypeError
+        passed: true
       - expected: 3
         id: ' .main._resources.app.add.add - 0.0 - Return the result of adding two integers '
         id_short: .main._resources.app.add.add

--- a/main/plugin.yaml
+++ b/main/plugin.yaml
@@ -42,14 +42,6 @@ options:
     required: false
     # type: str
   help: A list of strings. Exclude python files containing on of the strings
-- args: resources-folder-name
-  options:
-    action: store
-    help: The names of folders containing resources for tests.
-    default: _resources
-    dest: resources_folder_name
-    required: false
-  help: A string. The names of folders containing resources for tests.
 - args: yaml-suffix
   options:
     action: store

--- a/main/plugin_test.yaml
+++ b/main/plugin_test.yaml
@@ -161,12 +161,11 @@ tests:
           - project-path
           - include-functions
           - exclude-files
-          - resources-folder-name
           - yaml-suffix
           - logging-enabled
     - method: assertions.app.check_length
       field: _anonymous.options
-      expected: 7
+      expected: 6
 - function: pass_through
   description: Returns the data passed into the function
   tests:

--- a/main/process/locations.py
+++ b/main/process/locations.py
@@ -23,7 +23,6 @@ def main(
   exclude_files: str | List[str] | None = None,
   exclude_functions: str | List[str] | None = None,
   yaml_suffix: str | None = None,
-  resources_folder_name: str | None = None,
   resources: list | str | None = None,
   logging_enabled: bool | None = None,
   timestamp: int | float | None = None,
@@ -76,13 +75,6 @@ def format_yaml_suffix(yaml_suffix: str | None = None) -> sns:
   return sns(yaml_suffix=yaml_suffix)
 
 
-def format_resources_folder_name(
-  resources_folder_name: str | None = None,
-) -> sns:
-  resources_folder_name = resources_folder_name or CONFIG.resources_folder_name
-  return sns(resources_folder_name=resources_folder_name)
-
-
 def format_exclude_files(exclude_files: str | list | None = None) -> sns:
   if isinstance(exclude_files, list):
     exclude_files = [*exclude_files, *CONFIG.exclude_files]
@@ -105,11 +97,9 @@ def format_resources(resources: list | str | None = None) -> sns:
 def flag_for_exclusion(
   root: str | None = None,
   exclude_files: list | None = None,
-  resources_folder_name: str | None = None,
 ) -> bool:
   exclude_files = exclude_files or []
-  patterns = [*exclude_files, str(resources_folder_name)]
-  for pattern in patterns:
+  for pattern in exclude_files:
     if root.find(pattern) > -1:
       return True
   return False
@@ -127,11 +117,10 @@ def get_route_for_module(
 
 def get_module_and_yaml_location_when_path_kind_is_file(
   exclude_files: list | None = None,
-  resources_folder_name: str | None = None,
   paths: sns | None = None,
   yaml_suffix: str | None = None,
 ) -> sns:
-  _ = exclude_files, resources_folder_name
+  _ = exclude_files
 
   data = sns(locations=[])
 
@@ -169,7 +158,6 @@ def get_module_and_yaml_location_when_path_kind_is_file(
 
 def get_module_and_yaml_location_when_path_kind_is_directory(
   exclude_files: list | None = None,
-  resources_folder_name: str | None = None,
   paths: sns | None = None,
   yaml_suffix: str | None = None,
 ) -> sns:
@@ -179,11 +167,7 @@ def get_module_and_yaml_location_when_path_kind_is_directory(
   store = []
 
   for root, dirs, files in os.walk(paths.directory):
-    if flag_for_exclusion(
-      root=root,
-      exclude_files=exclude_files,
-      resources_folder_name=resources_folder_name,
-    ):
+    if flag_for_exclusion(root=root, exclude_files=exclude_files):
       continue
 
     for file in files:
@@ -204,30 +188,6 @@ def get_module_and_yaml_location_when_path_kind_is_directory(
         store.append(location)
 
   return sns(locations=store)
-
-
-def get_location_of_resources(
-  locations: list | None = None,
-  resources_folder_name: str | None = None,
-  exclude_files: list | None = None,
-) -> sns:
-  for item in locations:
-    resources = []
-    directory = os.path.dirname(item.module)
-    directory = os.path.join(directory, resources_folder_name)
-
-    for root, dirs, files in os.walk(directory):
-      if flag_for_exclusion(root=root, exclude_files=exclude_files):
-        continue
-
-      for file in files:
-        if file.endswith(CONFIG.module_extension):
-          location = os.path.join(root, file)
-          resources.append(location)
-
-    item.resources = resources
-
-  return sns(locations=locations)
 
 
 def examples() -> None:

--- a/main/process/locations.yaml
+++ b/main/process/locations.yaml
@@ -19,9 +19,6 @@ yaml_suffix: _test
 exclude_functions: []
 
 
-resources_folder_name: _resources
-
-
 yaml_extensions:
 - .yaml
 - .yml
@@ -55,8 +52,6 @@ operations:
   main:
   - format_paths
   - format_yaml_suffix
-  - format_resources_folder_name
   - format_exclude_files
   - get_module_and_yaml_location_when_path_kind_is_file
   - get_module_and_yaml_location_when_path_kind_is_directory
-  - get_location_of_resources

--- a/main/process/locations_test.yml
+++ b/main/process/locations_test.yml
@@ -23,10 +23,9 @@ tests:
   - method: _locations_resources.app.list_sns_to_list_dict
     field: locations
   tests:
-  - description: Project directory does not exist
+  - description: Project path does not exist
     arguments:
       project_path: does/not/exist
-      resources_folder_name: resources_folder_name
       exclude_files: exclusion_pattern
       yaml_suffix: _test
     assertions:
@@ -38,10 +37,9 @@ tests:
     - method: assertions.app.check_sns
       expected:
         locations: []
-  - description: Project directory does exist
+  - description: Project path is a directory
     arguments:
       project_path: *RESOURCES
-      resources_folder_name: resources_folder_name
       exclude_files: exclusion_pattern
       yaml_suffix: _test
     assertions:
@@ -51,16 +49,10 @@ tests:
         - module: ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/process/_locations_resources/exclusion_pattern.py
           module_location: ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/process/_locations_resources/exclusion_pattern.py
           module_route: .main.process._locations_resources.exclusion_pattern
-          resources:
-          - ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/process/_locations_resources/resources_folder_name/resource_b.py
-          - ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/process/_locations_resources/resources_folder_name/resource_a.py
           yaml: ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/process/_locations_resources/exclusion_pattern_test.yml
         - module: ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/process/_locations_resources/app.py
           module_location: ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/process/_locations_resources/app.py
           module_route: .main.process._locations_resources.app
-          resources:
-          - ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/process/_locations_resources/resources_folder_name/resource_b.py
-          - ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/process/_locations_resources/resources_folder_name/resource_a.py
           yaml: ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/process/_locations_resources/app_test.yml
 - function: format_paths
   description: >
@@ -130,23 +122,6 @@ tests:
     - method: assertions.app.check_sns
       expected:
         yaml_suffix: _yaml_suffix
-- function: format_resources_folder_name
-  description: Sets the resources folder names for modules
-  tests:
-  - description: Undefined argument
-    arguments:
-      resources_folder_name: null
-    assertions:
-    - method: assertions.app.check_sns
-      expected:
-        resources_folder_name: _resources
-  - description: Defined argument
-    arguments:
-      resources_folder_name: resources_folder_name
-    assertions:
-    - method: assertions.app.check_sns
-      expected:
-        resources_folder_name: resources_folder_name
 - function: format_exclude_files
   description: >
     Returns a list strings that are patterns used to
@@ -235,16 +210,14 @@ tests:
     arguments:
       root: null
       exclude_files: null
-      resources_folder_name: null
     assertions:
-    - method: assertions.app.check_exception
-      expected: AttributeError
+    - method: assertions.app.check_equals
+      expected: False
   - description: Path flagged for exclusion
     arguments:
       root: pattern_a/resources_folder_name
       exclude_files:
       - pattern_a
-      resources_folder_name: resources_folder_name
     assertions:
     - method: assertions.app.check_equals
       expected: True
@@ -254,7 +227,6 @@ tests:
       exclude_files:
       - pattern_a
       - pattern_b
-      resources_folder_name: resources_folder_name
     assertions:
     - method: assertions.app.check_equals
       expected: False
@@ -317,7 +289,6 @@ tests:
   - description: Path is the location of a module file
     arguments:
       exclude_files: []
-      resources_folder_name: resources_folder_name
       yaml_suffix: _test
       paths:
         kind: file
@@ -334,7 +305,6 @@ tests:
   - description: Path is the location of a YAML file
     arguments:
       exclude_files: []
-      resources_folder_name: resources_folder_name
       yaml_suffix: _test
       paths:
         kind: file
@@ -375,7 +345,6 @@ tests:
     arguments:
       exclude_files:
       - exclusion_pattern
-      resources_folder_name: resources_folder_name
       paths:
         root: *ROOT
         directory: *RESOURCES
@@ -393,39 +362,3 @@ tests:
           module_location: ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/process/_locations_resources/app.py
           module_route: .main.process._locations_resources.app
           yaml: ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/process/_locations_resources/app_test.yml
-- function: get_location_of_resources
-  description: >
-    Returns the location of resources or modules associated with the module
-    being tested
-  cast_arguments:
-  - field: locations
-    method: _locations_resources.app.list_dict_to_list_sns
-  cast_output:
-  - field: locations
-    method: _locations_resources.app.list_sns_to_list_dict
-  tests:
-  - description: Undefined arguments
-    arguments:
-      locations: null
-      resources_folder_name: null
-      exclude_files: null
-    assertions:
-    - method: assertions.app.check_exception
-      expected: TypeError
-  - description: Defined arguments
-    arguments:
-      resources_folder_name: resources_folder_name
-      exclude_files:
-      - exclusion_pattern
-      locations:
-      - yaml: ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/process/_locations_resources/app.yml
-        module: ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/process/_locations_resources/app.py
-    assertions:
-    - method: assertions.app.check_sns
-      expected:
-        locations:
-        - yaml: ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/process/_locations_resources/app.yml
-          module: ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/process/_locations_resources/app.py
-          resources:
-          - ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/process/_locations_resources/resources_folder_name/resource_b.py
-          - ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/process/_locations_resources/resources_folder_name/resource_a.py

--- a/main/utils/_resources/logger/app.py
+++ b/main/utils/_resources/logger/app.py
@@ -25,9 +25,7 @@ def get_logger_wrapper(logger: Any | None = None) -> logging.Logger:
 
 
 def examples() -> None:
-  invoke_testing_method.main(
-    resource_flag=True,
-    resources_folder_name='_resources', )
+  invoke_testing_method.main(resource_flag=True, resources_folder_name='_resources')
 
 
 if __name__ == '__main__':

--- a/main/utils/_resources/set_object.py
+++ b/main/utils/_resources/set_object.py
@@ -58,9 +58,7 @@ def reset_route_values_cast_arguments(
 def examples() -> None:
   from main.utils import invoke_testing_method
 
-  invoke_testing_method.main(
-    resource_flag=True,
-    resources_folder_name='_resources', )
+  invoke_testing_method.main(resource_flag=True, resources_folder_name='_resources')
 
 
 if __name__ == '__main__':

--- a/main/utils/invoke_testing_method.py
+++ b/main/utils/invoke_testing_method.py
@@ -20,7 +20,7 @@ LOCALS = locals()
 
 CONFIG = '''
   default_arguments:
-    resources_folder_name: _resources
+    resources_folder_name: ''
     yaml_suffix: _test
     resource_suffix: _resource
     exclude_files:
@@ -160,7 +160,6 @@ def run_tests_using_invocation_method(
 def invoke_plugin(
   location: str | None = None,
   exclude_files: str | List[str] | None = None,
-  resources_folder_name: str | None = None,
   yaml_suffix: str | None = None,
   logging_enabled: bool | None = None,
 ) -> sns:
@@ -168,7 +167,6 @@ def invoke_plugin(
     exclude_files=exclude_files,
     project_path=location,
     yaml_suffix=yaml_suffix,
-    resources_folder_name=resources_folder_name,
     logging_enabled=logging_enabled, )
   independent.get_task_from_event_loop(task=result)
   return sns(result=result)
@@ -177,7 +175,6 @@ def invoke_plugin(
 def invoke_pytest(
   location: str | None = None,
   exclude_files: str | None = None,
-  resources_folder_name: str | None = None,
   yaml_suffix: str | None = None,
   logging_enabled: bool | None = None,
 ) -> sns:
@@ -190,7 +187,6 @@ def invoke_pytest(
     -vvv
     -ra
     --tb=short
-    --resources-folder-name={resources_folder_name}
     --project-path={location}
     --yaml-suffix={yaml_suffix}
     --logging-enabled={logging_enabled}

--- a/main/utils/invoke_testing_method_test.yml
+++ b/main/utils/invoke_testing_method_test.yml
@@ -24,7 +24,6 @@ tests:
         module_filename: null
         resource_flag: false
         resource_suffix: _resource
-        resources_folder_name: _resources
         root_flag: false
         yaml_suffix: _test
         logging_enabled: true
@@ -34,7 +33,6 @@ tests:
       module: module
       module_filename: module_filename
       exclude_files: exclude_files
-      resources_folder_name: resources_folder_name
       yaml_suffix: yaml_suffix
       method: method
       resource_flag: resource_flag
@@ -51,7 +49,6 @@ tests:
         module_filename: module_filename
         resource_flag: resource_flag
         resource_suffix: resource_suffix
-        resources_folder_name: resources_folder_name
         root_flag: root_flag
         yaml_suffix: yaml_suffix
         logging_enabled: logging_enabled
@@ -62,7 +59,6 @@ tests:
     arguments:
       parent_filename: null
       resource_module: null
-      resources_folder_name: null
       resource_suffix: null
     assertions:
     - method: assertions.app.check_exception
@@ -71,7 +67,6 @@ tests:
     arguments:
       parent_filename: null
       resource_module: directory/module_resource
-      resources_folder_name: null
       resource_suffix: _resource
     assertions:
     - method: assertions.app.check_equals
@@ -85,11 +80,10 @@ tests:
       expected: directory/module.py
   - description: Resource module and folder name are defined
     arguments:
-      resource_module: directory/_resources/module.py
-      resources_folder_name: _resources
+      resource_module: directory/_resource/module.py
     assertions:
     - method: assertions.app.check_equals
-      expected: directory/module.py
+      expected: directory/_resource/module.py
   - description: Resource module parent module filename are defined
     arguments:
       resource_module: directory/module_resource.py
@@ -99,13 +93,12 @@ tests:
       expected: directory/module.py
   - description: All arguments are defined
     arguments:
-      resource_module: directory/_resources/module_resource.py
+      resource_module: directory/_resource/module_resource.py
       parent_filename: app
       resource_suffix: _resource
-      resources_folder_name: _resources
     assertions:
     - method: assertions.app.check_equals
-      expected: directory/app.py
+      expected: directory/_resource/app.py
 - function: set_location
   description: Set the location of a file or directory of files to test
   tests:
@@ -155,22 +148,15 @@ tests:
   - description: Resource flag is true and associated fields are defined
     arguments:
       resource_flag: true
-      module: _resources/module_resource.py
+      module: _resource/module_resource.py
       resource_suffix: _resource
-      resources_folder_name: _resources
     assertions:
     - method: assertions.app.check_sns
       expected:
-        location: module.py
+        location: _resource/module.py
         module: null
         root_flag: null
         resource_flag: null
-
-  # - description:
-  #   arguments:
-  #   assertions:
-  #   - method: assertions.app.
-  #     expected: 
 - function: invoke_plugin
   description: Run tests by invoking the PYTEST YAML app
   tests:
@@ -178,7 +164,6 @@ tests:
     arguments: &MODULE_WITH_TESTS_ARGUMENTS
       location: ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/utils/_resources/invoke_testing_method/module_with_tests.py
       exclude_files: []
-      resources_folder_name: resources_folder_name
       yaml_suffix: _test
       logging_enabled: True
     assertions:
@@ -214,7 +199,6 @@ tests:
     arguments: &MODULE_WITHOUT_TESTS_ARGUMENTS
       location: ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/utils/_resources/invoke_testing_method/module_without_tests.py
       exclude_files: []
-      resources_folder_name: resources_folder_name
       yaml_suffix: _test
       logging_enabled: True
     assertions:
@@ -281,7 +265,6 @@ tests:
   - description: Run tests on modules in a directory using plugin invocation method
     arguments:
       location: ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/utils/_resources/invoke_testing_method/
-      resources_folder_name: resources_folder_name
       method: plugin
       yaml_suffix: _test
       logging_enabled: True

--- a/main/utils/schema.yaml
+++ b/main/utils/schema.yaml
@@ -117,10 +117,6 @@ main.app.Data: &MAIN_DATA
     type: str | list
     description: Functions to filter or include for testing
     default: null
-  - name: resources_folder_name
-    type: str
-    description: The name of folders containing resource modules
-    default: null
   - name: yaml_suffix
     type: str
     description: Suffix for YAML files containing tests


### PR DESCRIPTION
`resources_folder_name` is only used when invoking app from a resource module; remove other unused references of the variable in the app.