### PR TITLE
Remove references to module location variable

### DIFF
--- a/main/app.py
+++ b/main/app.py
@@ -85,25 +85,21 @@ def handle_id(
 
 def handle_module(
   module: str | None = None,
-  module_location: str | None = None,
   module_route: List[str] | str | None = None,
   key: str | None = None,
 ) -> sns:
-  module = get_module.main(
+  temp = get_module.main(
     location=module,
     name=module_route,
     key=key,
     pool=False, )
+  if isinstance(temp, ModuleType):
+    return sns(module=temp)
 
-  log = None
-  if not isinstance(module, ModuleType):
-    log = sns(
-      message=f'No module at location {module_location}',
-      location=__file__,
-      operation='handle_module',
-      level='warning', )
-
-  return sns(module=module, log=log)
+  log = sns(
+    message=f'No module at location {module}',
+    level='warning', )
+  return sns(log=log)
 
 
 def get_resource_route(

--- a/main/app_test.yaml
+++ b/main/app_test.yaml
@@ -82,9 +82,6 @@ tests:
     arguments: {}
     assertions:
     - method: assertions.app.check_sns
-      expected:
-        module: null
-    - method: assertions.app.check_sns
       field: log
       expected:
         message: No module at location None
@@ -92,11 +89,7 @@ tests:
   - description: Module does not exist at location
     arguments:
       module: module_location_does_not_exist
-      module_location: module_location_does_not_exist
     assertions:
-    - method: assertions.app.check_sns
-      expected:
-        module: null
     - method: assertions.app.check_sns
       field: log
       expected:

--- a/main/process/get_tests/app.py
+++ b/main/process/get_tests/app.py
@@ -16,13 +16,10 @@ LOCALS = locals()
 def main(
   yaml: str | None = None,
   module: str | None = None,
-  module_location: str | None = None,
   module_route: str | None = None,
   resources: str | None = None,
 ) -> sns:
   data = sns(**locals())
-  del yaml, module, module_location, module_route, resources
-
   data = independent.process_operations(
     operations=CONFIG.operations.main,
     functions=LOCALS,
@@ -42,7 +39,6 @@ def get_configurations_and_tests(yaml: str | None = None) -> sns:
 def format_locations(
   yaml: str | None = None,
   module: str | None = None,
-  module_location: str | None = None,
   module_route: str | None = None,
   resources: str | None = None,
 ) -> sns:

--- a/main/process/get_tests/app_test.yml
+++ b/main/process/get_tests/app_test.yml
@@ -43,7 +43,6 @@ tests:
           id_short: null
           key: null
           module: ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/process/get_tests/_resources/app.py
-          module_location: null
           module_route: ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/process/get_tests/_resources/app.py
           output: null
           patches: []
@@ -69,7 +68,6 @@ tests:
           id_short: null
           key: '0.0'
           module: ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/process/get_tests/_resources/app.py
-          module_location: null
           module_route: ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/process/get_tests/_resources/app.py
           output: null
           patches: []
@@ -95,7 +93,6 @@ tests:
           id_short: null
           key: '0.1'
           module: ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/process/get_tests/_resources/app.py
-          module_location: null
           module_route: ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/process/get_tests/_resources/app.py
           output: null
           patches: []
@@ -148,7 +145,6 @@ tests:
       expected:
         module: null
         module_route: null
-        module_location: null
         yaml: null
         resources: null
     - method: assertions.app.check_sns
@@ -156,14 +152,12 @@ tests:
       expected:
         module: null
         module_route: null
-        module_location: null
         yaml: null
         resources: null
   - description: Defined arguments
     arguments:
       module: module
       module_route: module_route
-      module_location: module_location
       yaml: yaml
       resources: resources
     assertions:
@@ -171,7 +165,6 @@ tests:
       expected:
         module: null
         module_route: null
-        module_location: null
         yaml: null
         resources: null
     - method: assertions.app.check_sns
@@ -179,7 +172,6 @@ tests:
       expected:
         module: module
         module_route: module_route
-        module_location: module_location
         yaml: yaml
         resources: resources
 - function: add_locations_to_configurations
@@ -206,7 +198,6 @@ tests:
       locations:
         module: module
         module_route: module_route
-        module_location: module_location
         yaml: yaml
         resources: resources
     assertions:
@@ -216,7 +207,6 @@ tests:
         configurations:
           module: module
           module_route: module_route
-          module_location: module_location
           yaml: yaml
           resources:
           - resources
@@ -261,7 +251,6 @@ tests:
           id_short: null
           key: null
           module: null
-          module_location: null
           module_route: null
           output: null
           patches: []
@@ -297,7 +286,6 @@ tests:
           id_short: null
           key: '0.0'
           module: null
-          module_location: null
           module_route: null
           output: null
           patches: []
@@ -321,7 +309,6 @@ tests:
           id_short: null
           key: '0.1'
           module: null
-          module_location: null
           module_route: null
           output: null
           patches: []

--- a/main/process/get_tests/combine_fields.yml
+++ b/main/process/get_tests/combine_fields.yml
@@ -45,7 +45,6 @@ combine_fields_as:
   project_path: high
   module: high
   module_route: high
-  module_location: high
   yaml: high
   key: high
   # Choose low level

--- a/main/process/get_tests/expand_node_test.yml
+++ b/main/process/get_tests/expand_node_test.yml
@@ -48,7 +48,6 @@ tests:
           id_short: null
           key: null
           module: null
-          module_location: null
           module_route: null
           output: null
           patches: []
@@ -65,7 +64,6 @@ tests:
         yaml: yaml
         module: module
         module_route: module_route
-        module_location: module_location
         resources: resources
     assertions:
     - method: assertions.app.check_sns
@@ -86,7 +84,6 @@ tests:
           id_short: null
           key: '0.0'
           module: module
-          module_location: module_location
           module_route: module_route
           output: null
           patches: []
@@ -109,7 +106,6 @@ tests:
           id_short: null
           key: '0.1'
           module: module
-          module_location: module_location
           module_route: module_route
           output: null
           patches: []
@@ -129,7 +125,6 @@ tests:
         yaml: configurations
         module: configurations
         module_route: configurations
-        module_location: configurations
         resources: configurations
     assertions:
     - method: assertions.app.check_sns
@@ -151,7 +146,6 @@ tests:
           id_short: null
           key: '0.0'
           module: configurations
-          module_location: configurations
           module_route: configurations
           output: null
           patches: []
@@ -175,7 +169,6 @@ tests:
           id_short: null
           key: 0.1.0
           module: configurations
-          module_location: configurations
           module_route: configurations
           output: null
           patches: []
@@ -199,7 +192,6 @@ tests:
           id_short: null
           key: 0.1.1
           module: configurations
-          module_location: configurations
           module_route: configurations
           output: null
           patches: []
@@ -233,7 +225,6 @@ tests:
         id_short: null
         key: null
         module: null
-        module_location: null
         module_route: null
         output: null
         patches: []
@@ -245,13 +236,11 @@ tests:
       root_node:
         module: root_node
         module_route: root_node
-        module_location: root_node
         resources: root_node
         yaml: root_node
       configurations:
         module: configurations
         module_route: configurations
-        module_location: configurations
         resources: configurations
         yaml: configurations
     assertions:
@@ -273,7 +262,6 @@ tests:
         id_short: null
         key: null
         module: configurations
-        module_location: configurations
         module_route: configurations
         output: null
         patches: []
@@ -306,7 +294,6 @@ tests:
         description: root_node
         module: root_node
         module_route: root_node
-        module_location: root_node
         resources: root_node
         yaml: root_node
       nested_nodes:
@@ -333,7 +320,6 @@ tests:
           id_short: null
           key: key.0
           module: root_node
-          module_location: root_node
           module_route: root_node
           output: null
           patches: []
@@ -359,7 +345,6 @@ tests:
           id_short: null
           key: key.1
           module: root_node
-          module_location: root_node
           module_route: root_node
           output: null
           patches: []
@@ -432,7 +417,6 @@ tests:
             id_short: null
             key: '0.0'
             module: null
-            module_location: null
             module_route: null
             output: null
             patches: []
@@ -457,7 +441,6 @@ tests:
             id_short: null
             key: '0.1'
             module: null
-            module_location: null
             module_route: null
             output: null
             patches: []
@@ -482,7 +465,6 @@ tests:
             id_short: null
             key: '0.2'
             module: null
-            module_location: null
             module_route: null
             output: null
             patches: []

--- a/main/process/locations.py
+++ b/main/process/locations.py
@@ -151,7 +151,6 @@ def get_module_and_yaml_location_when_path_kind_is_file(
   location.module_route = get_route_for_module(
     root=paths.root,
     module=location.module, )
-  location.module_location = location.module
   data.locations.append(location)
   return data
 
@@ -181,7 +180,6 @@ def get_module_and_yaml_location_when_path_kind_is_directory(
         location.module = location.yaml.replace(
           yaml_ending,
           CONFIG.module_extension, )
-        location.module_location = location.module
         location.module_route = get_route_for_module(
           root=paths.root,
           module=location.module, )

--- a/main/process/locations_test.yml
+++ b/main/process/locations_test.yml
@@ -47,11 +47,9 @@ tests:
       expected:
         locations:
         - module: ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/process/_locations_resources/exclusion_pattern.py
-          module_location: ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/process/_locations_resources/exclusion_pattern.py
           module_route: .main.process._locations_resources.exclusion_pattern
           yaml: ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/process/_locations_resources/exclusion_pattern_test.yml
         - module: ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/process/_locations_resources/app.py
-          module_location: ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/process/_locations_resources/app.py
           module_route: .main.process._locations_resources.app
           yaml: ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/process/_locations_resources/app_test.yml
 - function: format_paths
@@ -299,7 +297,6 @@ tests:
       expected:
         locations:
         - module: ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/process/_locations_resources/exclusion_pattern.py
-          module_location: ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/process/_locations_resources/exclusion_pattern.py
           module_route: .main.process._locations_resources.exclusion_pattern
           yaml: ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/process/_locations_resources/exclusion_pattern_test.yml
   - description: Path is the location of a YAML file
@@ -315,7 +312,6 @@ tests:
       expected:
         locations:
         - module: ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/process/_locations_resources/exclusion_pattern.py
-          module_location: ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/process/_locations_resources/exclusion_pattern.py
           module_route: .main.process._locations_resources.exclusion_pattern
           yaml: ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/process/_locations_resources/exclusion_pattern_test.yml
 - function: get_module_and_yaml_location_when_path_kind_is_directory
@@ -355,10 +351,8 @@ tests:
       expected:
         locations:
         - module: ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/process/_locations_resources/exclusion_pattern.py
-          module_location: ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/process/_locations_resources/exclusion_pattern.py
           module_route: .main.process._locations_resources.exclusion_pattern
           yaml: ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/process/_locations_resources/exclusion_pattern_test.yml
         - module: ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/process/_locations_resources/app.py
-          module_location: ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/process/_locations_resources/app.py
           module_route: .main.process._locations_resources.app
           yaml: ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/process/_locations_resources/app_test.yml

--- a/main/utils/schema.yaml
+++ b/main/utils/schema.yaml
@@ -17,10 +17,6 @@ Test: &TEST
     type: Any
     description: A module or the location to a module in the file system
     default: null
-  - name: module_location
-    type: str
-    description: Location of a module in the file system
-    default: null
   - name: function
     type: str
     description: Name of the function to test


### PR DESCRIPTION
References to the variable `module_location`  should  not be present in the code or output from running tests.