### PR TITLE
Adding logic to enable spying on methods

### DIFF
--- a/assertions/app.py
+++ b/assertions/app.py
@@ -592,6 +592,32 @@ def check_file_exists(
   return data
 
 
+def check_spies(
+  module: ModuleType | None = None,
+  output: str | None = None,
+  expected: str | None = None,
+) -> sns:
+  _ = output
+
+  store = {}
+  passed = True
+
+  for key, values in expected.items():
+    spy_store = {}
+
+    for field, value in values.items():
+      route = f'SPIES.{key}.{field}'
+      spy_store[field] = get_object.main(parent=module, route=route)
+
+    store[key] = spy_store
+
+  passed = store == expected
+  return sns(
+    output=store,
+    expected=expected,
+    passed=passed, )
+
+
 def examples() -> None:
   from main.utils import invoke_testing_method
 

--- a/assertions/app.py
+++ b/assertions/app.py
@@ -20,9 +20,12 @@ class DataClass:
 
 
 def check_sns(
+  module: ModuleType | None = None,
   expected: dict | None = None,
   output: sns | None = None,
 ) -> sns:
+  _ = module
+
   type_checks = perform_type_checks(
     output=output,
     output_check=isinstance(output, sns),
@@ -69,9 +72,12 @@ def failed_type_check(
 
 
 def check_exception(
+  module: ModuleType | None = None,
   expected: str | None = None,
   output: Exception | dict | None = None,
 ) -> sns:
+  _ = module
+
   type_checks = perform_type_checks(
     output=output,
     output_check=isinstance(output, Exception),
@@ -89,9 +95,12 @@ def check_exception(
 
 
 def check_module(
+  module: ModuleType | None = None,
   output: ModuleType | None = None,
   expected: dict | None = None,
 ) -> sns:
+  _ = module
+
   if not isinstance(output, ModuleType):
     return sns(
       passed=False,
@@ -115,17 +124,26 @@ def check_module(
 
 
 def check_equals(
+  module: ModuleType | None = None,
   output: Any | None = None,
   expected: Any | None = None,
 ) -> sns:
+  _ = module
+
   passed = output == expected
-  return sns(**locals())
+  return sns(
+    expected=expected,
+    output=output,
+    passed=passed, )
 
 
 def check_function(
+  module: ModuleType | None = None,
   output: Callable | None = None,
   expected: dict | None = None,
 ) -> sns:
+  _ = module
+
   if not isinstance(output, Callable):
     return failed_type_check(
       output=output,
@@ -169,9 +187,12 @@ def perform_type_checks(
 
 
 def check_dataclass(
+  module: ModuleType | None = None,
   output: DataClass | None = None,
   expected: dict | None = None,
 ) -> sns:
+  _ = module
+
   output_check = dc.is_dataclass(output)
   expected_check = isinstance(expected, dict)
   type_checks = perform_type_checks(
@@ -198,9 +219,12 @@ def check_dataclass(
 
 
 def check_class(
+  module: ModuleType | None = None,
   output: object | None = None,
   expected: dict | None = None,
 ) -> sns:
+  _ = module
+
   output_check = inspect.isclass(output) or hasattr(object, '__bases__')
   type_checks = perform_type_checks(
     output=output,
@@ -224,9 +248,12 @@ def check_class(
 
 
 def check_length(
+  module: ModuleType | None = None,
   output: Any | None = None,
   expected: Any | None = None,
 ) -> sns:
+  _ = module
+
   output_check = hasattr(output, '__len__')
   expected_check = isinstance(expected, int)
   type_checks = perform_type_checks(
@@ -245,9 +272,12 @@ def check_length(
 
 
 def check_type(
+  module: ModuleType | None = None,
   output: Any | None = None,
   expected: Any | None = None,
 ) -> sns:
+  _ = module
+
   expected_check = isinstance(expected, str | list)
   type_checks = perform_type_checks(
     output=output,
@@ -285,9 +315,12 @@ def check_type(
 
 
 def check_substring_in_string(
+  module: ModuleType | None = None,
   output: str | None = None,
   expected: list | str | None = None,
 ) -> sns:
+  _ = module
+
   type_checks = perform_type_checks(
     output=output,
     output_check=isinstance(output, str | list),
@@ -310,9 +343,12 @@ def check_substring_in_string(
 
 
 def check_item_in_list(
+  module: ModuleType | None = None,
   output: list | tuple | None = None,
   expected: Any | None = None,
 ) -> sns:
+  _ = module
+
   type_checks = perform_type_checks(
     output=output,
     output_check=isinstance(output, list | tuple),
@@ -334,9 +370,12 @@ def check_item_in_list(
 
 
 def check_list_contains_item(
+  module: ModuleType | None = None,
   output: Any | None = None,
   expected: list | None = None,
 ) -> sns:
+  _ = module
+
   type_checks = perform_type_checks(
     output=output,
     output_check=True,
@@ -359,9 +398,12 @@ def check_list_contains_item(
 
 
 def check_key_in_dict(
+  module: ModuleType | None = None,
   output: dict | None = None,
   expected: list | str | None = None,
 ) -> sns:
+  _ = module
+
   type_checks = perform_type_checks(
     output=output,
     output_check=isinstance(output, dict),
@@ -382,9 +424,12 @@ def check_key_in_dict(
 
 
 def check_range(
+  module: ModuleType | None = None,
   output: dict | None = None,
   expected: dict | None = None,
 ) -> sns:
+  _ = module
+
   type_checks = perform_type_checks(
     output=output,
     output_check=isinstance(output, range),
@@ -402,9 +447,12 @@ def check_range(
 
 
 def check_key_value_in_dict(
+  module: ModuleType | None = None,
   output: dict | None = None,
   expected: dict | None = None,
 ) -> sns:
+  _ = module
+
   type_checks = perform_type_checks(
     output=output,
     output_check=isinstance(output, dict),
@@ -422,9 +470,12 @@ def check_key_value_in_dict(
 
 
 def check_thread(
+  module: ModuleType | None = None,
   output: list| threading.Thread | None = None,
   expected: list | dict | None = None,
 ) -> sns:
+  _ = module
+
   data = sns(**locals())
 
   type_checks = perform_type_checks(
@@ -497,9 +548,12 @@ def call_function(
 
 
 def check_function_output(
+  module: ModuleType | None = None,
   output: Callable | Awaitable | None = None,
   expected: Any | None = None,
 ) -> sns:
+  _ = module
+
   type_checks = perform_type_checks(
     output=output,
     output_check=isinstance(output, Callable | Awaitable),
@@ -525,9 +579,12 @@ def check_function_output(
 
 
 def check_file_exists(
+  module: ModuleType | None = None,
   output: str | None = None,
   expected: str | None = None,
 ) -> sns:
+  _ = module
+
   data = sns(**locals())
   data.passed = False
   if os.path.isfile(data.expected) and data.expected == data.output:

--- a/assertions/app_test.yaml
+++ b/assertions/app_test.yaml
@@ -1001,4 +1001,49 @@ tests:
         output:
         - '1'
         - '3'
-
+- function: check_spies
+  description: >
+    Verifies that spied on functions were called. Functions to check are listed
+    as keys in dictionary under the `expected` key under assertions. And the values
+    of keys in the dictionary should be `called` and/or `called_width`
+  cast_arguments:
+  - method: sns
+    field: module
+    unpack: true
+  tests:
+  - description: No spies defined
+    arguments:
+      module:
+        SPIES: {}
+      expected: {}
+      output: null
+    assertions:
+    - method: check_sns
+      expected:
+        output: {}
+        expected: {}
+        passed: true
+  - description: Spies defined
+    arguments:
+      module:
+        SPIES:
+          add:
+            called: False
+            called_with: None
+      expected:
+        add:
+          called: false
+          called_with: None
+      output: null
+    assertions:
+    - method: check_sns
+      expected:
+        output:
+          add:
+            called: False
+            called_with: None
+        expected:
+          add:
+            called: False
+            called_with: None
+        passed: true

--- a/assertions/app_test.yaml
+++ b/assertions/app_test.yaml
@@ -1,6 +1,7 @@
 TODO:
 - Check if the "contains" assertions can be combined to reduce duplication of code
 - Need assertion for string/regex
+- Add ability to cast expected in assertions
 
 
 resources:

--- a/assertions/resource.py
+++ b/assertions/resource.py
@@ -111,7 +111,9 @@ def check_function_output_resource(
 def examples() -> None:
   from main.utils import invoke_testing_method
 
-  invoke_testing_method.main(resource_flag=True)
+  invoke_testing_method.main(
+    module_filename='app',
+    resource_flag=True, )
 
 
 if __name__ == '__main__':

--- a/examples/operations.py
+++ b/examples/operations.py
@@ -43,6 +43,14 @@ def subtract(data: sns | None = None) -> sns:
   return data
 
 
+def multiply(data: sns) -> sns:
+  data.result = 0
+  for i in range(data.a):
+    temp = sns(a=data.result, b=data.b)
+    data.result = add(temp).result
+  return data
+
+
 def constant(data: sns | None = None) -> sns:
   data.result = CONSTANT
   return data

--- a/examples/operations_test.yaml
+++ b/examples/operations_test.yaml
@@ -49,14 +49,14 @@ tests:
     arguments:
       a: 1
       b: 1
-      method: multiply
+      method: method_does_not_exist
     assertions:
     - method: assertions.app.check_sns
       expected:
         a: 1
         b: 1
         result: Method does not exist
-        method: multiply
+        method: method_does_not_exist
   # # Assertion fails when uncommented
   # - description: Assertion fails
   #   arguments:
@@ -334,3 +334,29 @@ tests:
       expected:
         a: 5
         result: 15
+- function: multiply
+  description: >
+    Returns the product of two integers. An example of spying on a function
+    to see if it is called.
+  spies:
+  - add
+  cast_arguments:
+  - field: data
+    method: sns
+    unpack: true
+  tests:
+  - description: Multiply two integers and check that a function was called
+    arguments:
+      data:
+        a: 3
+        b: 4
+    assertions:
+    - method: assertions.app.check_sns
+      expected:
+        a: 3
+        b: 4
+        result: 12
+    - method: assertions.app.check_spies
+      expected:
+        add:
+          called: true

--- a/main/app/app.py
+++ b/main/app/app.py
@@ -12,6 +12,7 @@ from main.process import casts, locations
 from main.process import environment as _environment
 from main.process import get_tests as _get_tests
 from main.process import patches as _patches
+from main.process import spies as _spies
 from main.utils import (
   get_config,
   get_module,
@@ -53,7 +54,15 @@ def main(
   return getattr(data, 'tests', None) or []
 
 
-def process_patches(
+def set_spies(
+  spies: list | None,
+  module: ModuleType,
+) -> ModuleType:
+  arguments = locals()
+  return _spies.main(**arguments)
+
+
+def set_patches(
   patches: list | None,
   module: ModuleType,
 ) -> ModuleType:

--- a/main/app/app.yaml
+++ b/main/app/app.yaml
@@ -74,8 +74,9 @@ operations:
   - handle_module
   - handle_resources
   - set_environment
-  - process_patches
+  - set_patches
   - handle_casting_arguments
+  - set_spies
   - get_function
   - get_function_output
   - handle_casting_output

--- a/main/app/app_test.yaml
+++ b/main/app/app_test.yaml
@@ -2,12 +2,9 @@ TODO:
 - Add support for user defined logic (example, run_test_for_*) following the example for assertions
 - Add logic for testing APIs
 - Make timestamps a list and append timestamp at each logical operation
-- Add switcher for unpacking based on value and caster in 'execute_test'
 - Add logic for safe loading or regular loading data from yaml files -> configuration safe_load=true
-- Add logic to exclude specified modules from being imported as resources; help prevent errors caused by circular references
 - Add wrapper logic back in for external libraries
 - Consolidate duplicate code for sync and async functions -> https://stackoverflow.com/questions/27290656/should-i-use-two-asyncio-event-loops-in-one-program/27298880#27298880
-- tests as the root key for all tests instead of functions
 
 
 configurations:

--- a/main/app/app_test.yaml
+++ b/main/app/app_test.yaml
@@ -37,7 +37,6 @@ tests:
         id_short: .main.app.resources.add.add
         log: null
         method: check_exception
-        module: null
         output: TypeError
         passed: true
       - expected: 3
@@ -45,7 +44,6 @@ tests:
         id_short: .main.app.resources.add.add
         log: null
         method: check_equals
-        module: null
         output: 3
         passed: true
 - function: handle_id
@@ -552,7 +550,6 @@ tests:
         id_short: .main.resources.add.app.add
         log: null
         method: check_equals
-        module: null
         output: 11
         passed: true
 - function: run_test_handler
@@ -598,7 +595,6 @@ tests:
           id_short: app.add.app.add
           log: null
           method: check_equals
-          module: null
           output: 2
           passed: true
 - function: run_tests
@@ -641,7 +637,6 @@ tests:
           id_short: add.app.app.add
           log: null
           method: check_exception
-          module: null
           output: TypeError
           passed: true
         - expected: 3
@@ -649,6 +644,5 @@ tests:
           id_short: add.app.app.add
           log: null
           method: check_equals
-          module: null
           output: 3
           passed: true

--- a/main/app/resources/app.py
+++ b/main/app/resources/app.py
@@ -55,7 +55,8 @@ def examples() -> None:
   from main.utils import invoke_testing_method
 
   invoke_testing_method.main(
-    resources_folder_name='_resources',
+    resources_folder_name='resources',
+    module_filename='app',
     resource_flag=True, )
 
 

--- a/main/plugin/app_test.yaml
+++ b/main/plugin/app_test.yaml
@@ -9,16 +9,13 @@ TODO:
 - complete test for add_args_and_ini_options_to_parser
 - complete test for get_options_or_inis
 - complete test for pytest_configure
-- implement a spy assertion and complete tests for pytest_configure and pytest_itemcollected can probably use pytest spy
 - make sure globally defined configs are pulled into app
 
 
 configurations:
   exclude_functions:
   - pytest_runtest_logreport
-  - pytest_itemcollected
   - pytest_addoption
-  - pytest_itemcollected
   # - pytest_configure
   resources:
   - ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/plugin/resources/app.py
@@ -243,3 +240,24 @@ tests:
     assertions:
     - method: assertions.app.check_equals
       expected: nodeid
+- function: pytest_itemcollected
+  description: Handles the collection of pytest test items
+  patches:
+  - route: set_node_ids
+    value: {}
+    method: callable
+  spies:
+  - set_node_ids
+  tests:
+  - description: Undefined arguments
+    arguments:
+      item: null
+    assertions:
+    - method: assertions.app.check_equals
+      expected: null
+    - method: assertions.app.check_spies
+      expected:
+        set_node_ids:
+          called: True
+          called_with:
+            item: null

--- a/main/process/assertions/app.py
+++ b/main/process/assertions/app.py
@@ -76,10 +76,11 @@ def pre_processing(
 def pass_through(method: str | None = None) -> Callable:
 
   def pass_through_inner(
+    module: ModuleType | None = None,
     output: Any | None = None,
     expected: Any | None = None,
   ) -> Callable:
-    _ = output, expected
+    _ = output, expected, module
 
     return sns(
       passed=False,
@@ -140,15 +141,17 @@ def cast_output(
 
 
 def get_assertion_result(
+  module: ModuleType | None = None,
   method: Callable | None = None,
   output: Any | None = None,
   expected: Any | None = None,
 ) -> sns:
   result = method(
+    module=module,
     output=output,
     expected=expected, )
   result.method = method.__name__
-  result.module = None
+  result._cleanup = ['module']
   return result
 
 

--- a/main/process/assertions/app_test.yml
+++ b/main/process/assertions/app_test.yml
@@ -55,7 +55,6 @@ tests:
           id: id
           id_short: id_short
           method: check_equals
-          module: null
           output: output
           passed: true
           log: null
@@ -70,7 +69,6 @@ tests:
       - expected: output
         method: check_equals
         output: output
-        module: null
         passed: true
         id: id
         id_short: id_short
@@ -106,7 +104,6 @@ tests:
       - expected:
           key: output_value
         method: check_equals
-        module: null
         output:
           key: output_value
         passed: true
@@ -118,7 +115,6 @@ tests:
         id_short: id_short
         log: '[]'
         method: check_equals
-        module: null
         output: 'key: output_value'
         passed: false
   - description: Assertion method does not exist
@@ -152,7 +148,6 @@ tests:
       
           ...'
         passed: false
-        module:  null
         log: '[]'
         id: id
         id_short: id_short

--- a/main/process/assertions/resource.py
+++ b/main/process/assertions/resource.py
@@ -29,9 +29,11 @@ def set_exception(assertion: Any) -> Any:
 
 
 def check_equals(
+  module: ModuleType,
   output: Any,
   expected: Any,
 ) -> sns:
+  _ = module
   passed = output == expected
   return sns(
     passed=passed,

--- a/main/process/casts/app_resource.py
+++ b/main/process/casts/app_resource.py
@@ -179,7 +179,9 @@ def get_resource(resource: Any | None = None) -> Callable:
 def examples() -> None:
   from main.utils import invoke_testing_method
 
-  invoke_testing_method.main(resource_flag=True)
+  invoke_testing_method.main(
+    module_filename='app',
+    resource_flag=True, )
 
 
 if __name__ == '__main__':

--- a/main/process/get_tests/app_test.yml
+++ b/main/process/get_tests/app_test.yml
@@ -48,6 +48,7 @@ tests:
           resources:
           - ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/process/get_tests/resources/resource.py
           - resource_configuration
+          spies: []
           tests: null
           yaml: ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/process/get_tests/resources/app_test.yml
         - arguments: {}
@@ -70,6 +71,7 @@ tests:
           module_route: ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/process/get_tests/resources/app.py
           output: null
           patches: []
+          spies: []
           resources:
           - ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/process/get_tests/resources/resource.py
           - resource_configuration
@@ -95,6 +97,7 @@ tests:
           module_route: ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/process/get_tests/resources/app.py
           output: null
           patches: []
+          spies: []
           resources:
           - ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/process/get_tests/resources/resource.py
           - resource_configuration
@@ -254,6 +257,7 @@ tests:
           output: null
           patches: []
           resources: []
+          spies: []
           tests: null
           yaml: null
   - description: Single node with nested nodes
@@ -289,6 +293,7 @@ tests:
           output: null
           patches: []
           resources: []
+          spies: []
           tests: null
           yaml: null
         - arguments: {}
@@ -312,5 +317,6 @@ tests:
           output: null
           patches: []
           resources: []
+          spies: []
           tests: null
           yaml: null

--- a/main/process/get_tests/combine_fields.yml
+++ b/main/process/get_tests/combine_fields.yml
@@ -38,6 +38,7 @@ combine_fields_as:
   exclude_functions: list
   environment: dict
   arguments: dict
+  spies: list
   # Choose low level if not null else high level
   function: low_or_high
   function_name: low_or_high

--- a/main/process/get_tests/expand_node_test.yml
+++ b/main/process/get_tests/expand_node_test.yml
@@ -52,6 +52,7 @@ tests:
           output: null
           patches: []
           resources: []
+          spies: []
           tests: null
           yaml: null
   - description: Root node with two nested nodes and defined configurations
@@ -89,6 +90,7 @@ tests:
           patches: []
           resources:
           - resources
+          spies: []
           tests: null
           yaml: yaml
         - arguments: {}
@@ -111,6 +113,7 @@ tests:
           patches: []
           resources:
           - resources
+          spies: []
           tests: null
           yaml: yaml
   - description: Root node with a nested node that has a nested node
@@ -151,6 +154,7 @@ tests:
           patches: []
           resources:
           - configurations
+          spies: []
           tests: null
           yaml: configurations
         - arguments: {}
@@ -174,6 +178,7 @@ tests:
           patches: []
           resources:
           - configurations
+          spies: []
           tests: null
           yaml: configurations
         - arguments: {}
@@ -197,6 +202,7 @@ tests:
           patches: []
           resources:
           - configurations
+          spies: []
           tests: null
           yaml: configurations
 - function: add_configurations_to_root_node
@@ -229,6 +235,7 @@ tests:
         output: null
         patches: []
         resources: []
+        spies: []
         tests: null
         yaml: null
   - description: Non-empty arguments
@@ -268,6 +275,7 @@ tests:
         resources:
         - configurations
         - root_node
+        spies: []
         tests: null
         yaml: configurations
 - function: expand_nested_nodes
@@ -325,6 +333,7 @@ tests:
           patches: []
           resources:
           - root_node
+          spies: []
           tests: null
           yaml: root_node
         key.1:
@@ -350,6 +359,7 @@ tests:
           patches: []
           resources:
           - root_node
+          spies: []
           tests: null
           yaml: root_node
 - function: get_expanded_nodes
@@ -421,6 +431,7 @@ tests:
             output: null
             patches: []
             resources: []
+            spies: []
             tests: null
             yaml: null
           '0.1':
@@ -445,6 +456,7 @@ tests:
             output: null
             patches: []
             resources: []
+            spies: []
             tests: null
             yaml: null
           '0.2':
@@ -469,6 +481,7 @@ tests:
             output: null
             patches: []
             resources: []
+            spies: []
             tests: null
             yaml: null
 - function: remove_roots_of_expanded_nodes

--- a/main/process/get_tests/resources/app.py
+++ b/main/process/get_tests/resources/app.py
@@ -25,7 +25,9 @@ def sns_to_dict(data: sns | list | None = None) -> dict | list | None:
 def examples() -> None:
   from main.utils import invoke_testing_method
 
-  invoke_testing_method.main(resource_flag=True)
+  invoke_testing_method.main(
+    resources_folder_name='resources',
+    resource_flag=True, )
 
 
 if __name__ == '__main__':

--- a/main/process/spies/__init__.py
+++ b/main/process/spies/__init__.py
@@ -1,0 +1,6 @@
+#!.venv/bin/python3
+# -*- coding: utf-8 -*-
+
+
+# trunk-ignore(ruff/F403)
+from .app import *

--- a/main/process/spies/app.py
+++ b/main/process/spies/app.py
@@ -1,0 +1,72 @@
+#!.venv/bin/python3
+# -*- coding: utf-8 -*-
+
+
+from types import ModuleType
+from types import SimpleNamespace as sns
+from typing import Callable
+
+from main.utils import get_object, independent, set_object
+
+
+MODULE = __file__
+LOCALS = locals()
+
+CONFIG = '''
+  operations:
+    main:
+    - spy_on_method
+'''
+CONFIG = independent.format_configurations_defined_in_module(config=CONFIG)
+
+
+def main(
+  module: ModuleType,
+  spies: list | None,
+) -> sns:
+  spies = spies or []
+  store = getattr(module, 'SPIES', None) or {}
+  setattr(module, 'SPIES', store)
+
+  for item in spies:
+    data = sns(module=module, route=item)
+    data = independent.process_operations(
+      operations=CONFIG.operations.main,
+      data=data,
+      functions=LOCALS, )
+    module = data.module
+
+  return sns(module=module, _cleanup=['spies'])
+
+
+def do_nothing(*args, **kwargs) -> None:
+  _ = args, kwargs
+
+
+def spy_on_method(
+  module: ModuleType,
+  route: str,
+) -> sns:
+  original = get_object.main(parent=module, route=route) or do_nothing
+
+  def spy(*args, **kwargs) -> Callable:
+    called_with = args or kwargs
+    module.SPIES[route] = sns(called=True, called_with=called_with)
+    return original(*args, **kwargs)
+
+  spy.__wrapped__ = original
+  spy._method = 'spy'
+
+  module.SPIES[route] = sns(called=False, called_with=None)
+  set_object.main(parent=module, value=spy, route=route)
+  return sns(module=module)
+
+
+def examples() -> None:
+  from main.utils import invoke_testing_method
+
+  invoke_testing_method.main(location=MODULE)
+
+
+if __name__ == '__main__':
+  examples()

--- a/main/process/spies/app_test.yaml
+++ b/main/process/spies/app_test.yaml
@@ -1,0 +1,129 @@
+TODO:
+- Add logic to cast expected
+
+
+configurations:
+  resources:
+  - ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/process/spies/resource.py
+  - ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/assertions/app.py
+
+
+tests:
+- function: main
+  description: >
+    Returns a module with spied on methods. SPIES are stored in a dictionary
+    in the module, and the key for spy on a method is the route to the method
+    from the module of the function being tested.
+  cast_arguments:
+  - method: resource.get_module_wrapper
+    field: module
+  tests:
+  - description: No spies defined
+    arguments:
+      spies: null
+      module: ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/process/spies/resource.py
+    assertions:
+    - method: assertions.app.check_type
+      expected: SimpleNamespace
+    - method: assertions.app.check_module
+      field: module
+      expected:
+        location: ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/process/spies/resource.py
+    - method: assertions.app.check_equals
+      field: module.SPIES
+      expected: {}
+  - description: Spies defined
+    arguments:
+      spies:
+      - add
+      - subtract
+      module: ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/process/spies/resource.py
+    assertions:
+    - method: assertions.app.check_equals
+      field: module.SPIES
+      cast_output:
+      - method: resource.dict_sns_to_dict_dict
+      expected:
+        add:
+          called: False
+          called_with: null
+        subtract:
+          called: False
+          called_with: null
+    - method: assertions.app.check_function
+      field: module.add
+      expected:
+        location: ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/process/spies/resource.py
+        name: add
+    - method: assertions.app.check_equals
+      field: module.subtract._method
+      expected: spy
+- function: do_nothing
+  description: Returns a null object
+  arguments: {}
+  assertions:
+  - method: assertions.app.check_equals
+    expect: null
+- function: spy_on_method
+  description: >
+    Wraps a method in a module in a spy to tell if the method was called
+    and what it was called with. Then adds spy to the module store of spies.
+  tests:
+  - description: Undefined arguments
+    arguments: {}
+    assertions:
+    - method: assertions.app.check_exception
+      expected: TypeError
+  - cast_arguments:
+      field: module
+      method: resource.get_module_wrapper
+    tests:
+    - description: Method does not exist in module
+      arguments:
+        module: ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/process/spies/resource.py
+        route: method_does_not_exist
+      assertions:
+      - method: assertions.app.check_module
+        field: module
+        expected:
+          location: ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/process/spies/resource.py
+      - method: assertions.app.check_equals
+        field: module.SPIES
+        cast_output:
+        - method: resource.dict_sns_to_dict_dict
+        expected:
+          method_does_not_exist:
+            called: False
+            called_with: null
+      - method: assertions.app.check_function
+        field: module.method_does_not_exist
+        expected:
+          name: do_nothing
+          location: ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/process/spies/app.py
+    - description: Method exists in module
+      arguments:
+        module: ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/process/spies/resource.py
+        route: add
+      assertions:
+      - method: assertions.app.check_equals
+        field: module.SPIES
+        cast_output:
+        - method: resource.dict_sns_to_dict_dict
+        expected:
+          add:
+            called: False
+            called_with: null
+    - description: Call spied on method
+      arguments:
+        module: ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/process/spies/resource.py
+        route: add
+      assertions:
+      - method: assertions.app.check_equals
+        cast_output:
+        - method: resource.call_spy
+        expected:
+          add:
+            called: True
+            called_with:
+              a: 1
+              b: 1

--- a/main/process/spies/resource.py
+++ b/main/process/spies/resource.py
@@ -39,12 +39,11 @@ def call_spy(output: sns) -> dict:
 
 
 def examples() -> None:
-  import os
-
   from main.utils import invoke_testing_method
 
-  location = os.path.dirname(MODULE)
-  invoke_testing_method.main(location=location)
+  invoke_testing_method.main(
+    module_filename='app',
+    resource_flag=True, )
 
 
 if __name__ == '__main__':

--- a/main/process/spies/resource.py
+++ b/main/process/spies/resource.py
@@ -1,0 +1,51 @@
+#!.venv/bin/python3
+# -*- coding: utf-8 -*-
+
+from types import ModuleType
+from types import SimpleNamespace as sns
+
+from main.utils import get_module
+
+
+MODULE = __file__
+LOCALS = locals()
+
+
+def get_module_wrapper(module: str) -> ModuleType:
+  module = get_module.main(location=module, pool=False)
+  if isinstance(module, ModuleType):
+    module.SPIES = getattr(module, 'SPIES', None) or {}
+  return module
+
+
+def dict_sns_to_dict_dict(output: dict) -> dict:
+  for key, value in output.items():
+    output[key] = value.__dict__
+  return output
+
+
+def add(a: int, b: int) -> int:
+  return a + b
+
+
+def subtract(a: int, b: int) -> int:
+  return a - b
+
+
+def call_spy(output: sns) -> dict:
+  module = output.module
+  _ = module.add(a=1, b=1)
+  return dict_sns_to_dict_dict(output=module.SPIES)
+
+
+def examples() -> None:
+  import os
+
+  from main.utils import invoke_testing_method
+
+  location = os.path.dirname(MODULE)
+  invoke_testing_method.main(location=location)
+
+
+if __name__ == '__main__':
+  examples()

--- a/main/utils/get_config/resources/app.py
+++ b/main/utils/get_config/resources/app.py
@@ -20,7 +20,9 @@ def format_environment_content_cast_arguments(
 def examples() -> None:
   from main.utils import invoke_testing_method
 
-  invoke_testing_method.main(resource_flag=True)
+  invoke_testing_method.main(
+    resources_folder_name='resources',
+    resource_flag=True, )
 
 
 if __name__ == '__main__':

--- a/main/utils/get_object/resource.py
+++ b/main/utils/get_object/resource.py
@@ -24,7 +24,9 @@ def get_module_wrapper(parent: str | None = None) -> ModuleType:
 def examples() -> None:
   from main.utils import invoke_testing_method
 
-  invoke_testing_method.main(resource_flag=True)
+  invoke_testing_method.main(
+    module_filename='app',
+    resource_flag=True, )
 
 
 if __name__ == '__main__':

--- a/main/utils/independent/app_test.yml
+++ b/main/utils/independent/app_test.yml
@@ -2,14 +2,7 @@ TODO:
 - Add test for decorated function and awaitable to ./main/app_test.yaml
 - Finalize logging and tests
 - Think of moving format_exception_and_trace to logger
-- |
-    Finish test for handle_logging. Need a spy:
-    - wrapper
-    - patch function with wrapper, wrappers has counter to keep track of times called and arguments passed in
-    - timestamp
-    - put this in the patch
-    - output should be sns with fields output, called - bool, called_with - dict, called_count - int
-    - will need the module
+- Finish test for the main function. May require a spy.
 
 
 resource:

--- a/main/utils/independent/resource.py
+++ b/main/utils/independent/resource.py
@@ -160,7 +160,9 @@ def check_method(
 def examples() -> None:
   from main.utils import invoke_testing_method
 
-  invoke_testing_method.main(resource_flag=True)
+  invoke_testing_method.main(
+    resource_flag=True,
+    module_filename='app', )
 
 
 if __name__ == '__main__':

--- a/main/utils/invoke_testing_method/app_test.yml
+++ b/main/utils/invoke_testing_method/app_test.yml
@@ -3,7 +3,6 @@ configurations:
   - run_pytest
   resources:
   - ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/utils/invoke_testing_method/resources/app.py
-  - ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/main/utils/invoke_testing_method/resources/resource.py
   - ${YAML_TESTING_FRAMEWORK_ROOT_DIR}/assertions/app.py
 
 
@@ -184,8 +183,7 @@ tests:
     - method: assertions.app.check_sns
       cast_output:
       - field: result
-        method: resources.resource.list_sns_to_list_dict
-        # method: resources.app.list_sns_to_list_dict
+        method: resources.app.list_sns_to_list_dict
       expected: &MODULE_WITH_TESTS_ASSERTION_EXPECTED
         result:
         - expected: Hello Earth
@@ -194,7 +192,6 @@ tests:
           id_short: .main.utils.invoke_testing_method.resources.module_with_tests.hello_world
           log: null
           method: check_equals
-          module: null
           output: Hello Earth
           passed: true
         - expected: Hello World
@@ -203,7 +200,6 @@ tests:
           id_short: .main.utils.invoke_testing_method.resources.module_with_tests.hello_world
           log: null
           method: check_equals
-          module: null
           output: Hello World
           passed: true
   - description: Location is a module with no defined tests
@@ -229,8 +225,7 @@ tests:
   description: Runs tests using one of the defined invocation methods
   cast_output:
   - field: result
-    method: resources.resource.list_sns_to_list_dict
-    # method: resources.app.list_sns_to_list_dict
+    method: resources.app.list_sns_to_list_dict
   tests:
   - description: Run tests by invoking plugin
     arguments:
@@ -246,7 +241,6 @@ tests:
           id_short: .main.utils.invoke_testing_method.resources.module_with_tests.hello_world
           log: null
           method: check_equals
-          module: null
           output: Hello Earth
           passed: true
         - expected: Hello World
@@ -255,7 +249,6 @@ tests:
           id_short: .main.utils.invoke_testing_method.resources.module_with_tests.hello_world
           log: null
           method: check_equals
-          module: null
           output: Hello World
           passed: true
 - function: main
@@ -288,7 +281,6 @@ tests:
             - 0.0 - Returns a greeting '
           id_short: .main.utils.invoke_testing_method.resources.module_with_tests.hello_world
           method: check_equals
-          module: null
           output: Hello World
           passed: true
         - expected: Hello Earth
@@ -296,6 +288,5 @@ tests:
             - 0.1 - Returns a greeting '
           id_short: .main.utils.invoke_testing_method.resources.module_with_tests.hello_world
           method: check_equals
-          module: null
           output: Hello Earth
           passed: true

--- a/main/utils/invoke_testing_method/resources/resource.py
+++ b/main/utils/invoke_testing_method/resources/resource.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 
 
-import os
 from types import SimpleNamespace as sns
 
 
@@ -25,9 +24,9 @@ def list_sns_to_list_dict(result: list | None = None) -> list | None:
 def examples() -> None:
   from main.utils import invoke_testing_method
 
-  location = os.path.dirname(MODULE)
-  location = os.path.dirname(location)
-  invoke_testing_method.main(location=location)
+  invoke_testing_method.main(
+    resources_folder_name='resources',
+    module_filename='app', )
 
 
 if __name__ == '__main__':

--- a/main/utils/logger/resources/app.py
+++ b/main/utils/logger/resources/app.py
@@ -35,7 +35,8 @@ def list_sns_to_list_dict(output: Any) -> Any:
 def examples() -> None:
   invoke_testing_method.main(
     resource_flag=True,
-    resources_folder_name='_resources', )
+    module_filename='app',
+    resources_folder_name='resources', )
 
 
 if __name__ == '__main__':

--- a/main/utils/logger/resources/app.py
+++ b/main/utils/logger/resources/app.py
@@ -25,6 +25,13 @@ def get_logger_wrapper(logger: Any | None = None) -> logging.Logger:
   return logger_resource.get_logger(location=logger)
 
 
+def list_sns_to_list_dict(output: Any) -> Any:
+  if not isinstance(output, list):
+    return output
+
+  return [item.__dict__ for item in output]
+
+
 def examples() -> None:
   invoke_testing_method.main(
     resource_flag=True,

--- a/main/utils/schema/app.yaml
+++ b/main/utils/schema/app.yaml
@@ -86,6 +86,12 @@ Test: &TEST
     type: str
     description: ey or unique identifier for a test
     default: null
+  - name: spies
+    type: list | str
+    description: >
+      A list of methods to spy, where each item in the list is the dot
+      delimited route to a method
+    default: null
 
 
 # Update names

--- a/main/utils/set_object/resource.py
+++ b/main/utils/set_object/resource.py
@@ -57,12 +57,11 @@ def reset_route_values_cast_arguments(
 
 
 def examples() -> None:
-  import os
-
   from main.utils import invoke_testing_method
 
-  location = os.path.dirname(MODULE)
-  invoke_testing_method.main(location=location)
+  invoke_testing_method.main(
+    module_filename='app',
+    resource_flag=True, )
 
 
 if __name__ == '__main__':

--- a/setup_test.yaml
+++ b/setup_test.yaml
@@ -1,7 +1,5 @@
 TODO:
-- revisit get_python_requires function
 - automate pushing to pypi; github hooks?
-- linting/formatting/trunk - ignore shebang and encoding at the top of module files
 - Process resources if a directory is specified
 
 


### PR DESCRIPTION
Should be able to define spies at various levels (configurations, module, tests) and access each spy from the module within an assertion method